### PR TITLE
fix hardware architecture to generic x86-64 sse2

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@ export CXX=$GXX # the sphinx configure script does not recognise x86_64-conda_co
 ./configure --prefix=${PREFIX} \
     OBJCXX=${CXX} \
     CFLAGS="${CFLAGS}" \
+    CXX_M_ARCH=-march=x86-64 \
     CPPFLAGS="${CPPFLAGS} -D__STDC_FORMAT_MACROS" \
     --enable-mkl --enable-mklfft --with-mklpath=${PREFIX} \
     --disable-debug --with-sxmath --enable-pcre2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: c0af776ca6b98ac9ed68a04437e4ba49cdc15a35665be65f696fc98ae4698e4b
 
 build:
-  number: 3
+  number: 4
   skip: true  # [not linux]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
might solve issue #34 (if related to incompatible hardware)
-->

<!--
Please add any other relevant info below:
-->
